### PR TITLE
correcting tree item selectable caret for fuel 3.1.0

### DIFF
--- a/less/fuelux/tree.less
+++ b/less/fuelux/tree.less
@@ -24,10 +24,16 @@
 
 	// ICONS - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	.icon-caret {
-		display: none;
+		top: -1px;
+		left: -1px;
 		.sprite(-176px, 0);
 		width: 13px;
 		height: 13px;
+	}
+
+	&.tree-folder-select .icon-caret {
+		top: 0;
+		left: 0;
 	}
 
 	.icon-caret:before, &.tree-folder-select .tree-branch-header .icon-caret:before {
@@ -98,7 +104,7 @@
 	}
 
 	.tree-item {
-		margin-left: 0;
+		margin-left: 16px;
 		padding: 0 3px 2px 8px;
 		border-radius: 0;
 		line-height: 16px;
@@ -147,10 +153,6 @@
 			&:before {
 				color: @blue-light;
 			}
-		}
-
-		.tree-item {
-			margin-left: 16px;
 		}
 	}
 


### PR DESCRIPTION
Caret now shows up for item selectable tree. Small margin changes to item selectable tree.
