### PR TITLE
Added css to set height and scroll content

### DIFF
--- a/examples/bootstrap-javascript/bootstrap-javascript-examples.css
+++ b/examples/bootstrap-javascript/bootstrap-javascript-examples.css
@@ -275,9 +275,3 @@
 .bs-example-modal  {
   background: #5a5a5a;
 }
-
-#myModal .scroll-body {
-	height: 400px;
-	overflow-y: scroll;
-}
-

--- a/examples/bootstrap-javascript/bootstrap-javascript.html
+++ b/examples/bootstrap-javascript/bootstrap-javascript.html
@@ -87,7 +87,7 @@
 								<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
 								<h4 class="modal-title" id="myModalLabel">Modal Heading</h4>
 							</div>
-							<div class="modal-body scroll-body">
+							<div class="modal-body">
 								<h4>Text in a modal</h4>
 								<p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</p>
 
@@ -98,12 +98,6 @@
 								<p><a href="#" class="tooltip-test" title="Tooltip">This link</a> and <a href="#" class="tooltip-test" title="Tooltip">that link</a> should have tooltips on hover.</p>
 
 								<hr>
-
-								<h4>Overflowing text to show scroll behavior</h4>
-								<p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
-								<p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
-								<p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
-								<p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
 								<p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
 								<p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
 								<p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>


### PR DESCRIPTION
Addresses issue #25. Modal scrolls its body content and will fit in the iframe under the
“Themed Bootstrap Controls” section found here:
http://exacttarget.github.io/fuelux/mctheme/index.html#mctheme
