### PR TITLE
Allow Repeater Selected Checkmark when using block level elements in table cell

### DIFF
--- a/less/fuelux/repeater-list.less
+++ b/less/fuelux/repeater-list.less
@@ -92,5 +92,9 @@
 				}
 			}
 		}
+
+		&-check {
+			float: left;
+		}
 	}
 }


### PR DESCRIPTION
Addresses issue #44 by floating the 'repeater-list-check'
