### PR TITLE
[CSS] Heading classes should not have margins. #60

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -47,3 +47,10 @@ h3, .h3 { font-size: @font-size-h3; }
 h4, .h4 { font-size: @font-size-h4; }
 h5, .h5 { font-size: @font-size-h5; }
 h6, .h6 { font-size: @font-size-h6; }
+
+.h1 { margin: 0; }
+.h2 { margin: 0; }
+.h3 { margin: 0; }
+.h4 { margin: 0; }
+.h5 { margin: 0; }
+.h6 { margin: 0; }


### PR DESCRIPTION
Fixes #60. Heading classes should not have margins.
