### PR TITLE
[wizard] Add previous button hover state, next as .btn-primary #72

### DIFF
--- a/examples/fuelux/fuelux.html
+++ b/examples/fuelux/fuelux.html
@@ -1435,7 +1435,7 @@
 				</ul>
 				<div class="actions">
 					<button class="btn btn-default btn-prev"><span class="glyphicon glyphicon-arrow-left"></span>Prev</button>
-					<button class="btn btn-default btn-next" data-last="Complete">Next<span class="glyphicon glyphicon-arrow-right"></span></button>
+					<button class="btn btn-primary btn-next" data-last="Complete">Next<span class="glyphicon glyphicon-arrow-right"></span></button>
 				</div>
 				<div class="step-content">
 					<div class="step-pane active sample-pane alert" data-step="1">

--- a/less/fuelux-override/wizard.less
+++ b/less/fuelux-override/wizard.less
@@ -19,6 +19,10 @@
 			border: none;
 			box-shadow: none;
 			color: #2168a7;
+			&:hover,
+			&:focus {
+				color: @link-hover-color;
+			}
 		}
 	}
 


### PR DESCRIPTION
Confusing previous button style in wizard #72

Make next button primary for increased theme consistency with style guide.
