### PR TITLE
Make column width and container padding the same

### DIFF
--- a/less/bootstrap-override/grid.less
+++ b/less/bootstrap-override/grid.less
@@ -1,0 +1,13 @@
+//
+// Grid
+// --------------------------------------------------
+
+.container {
+	padding-right: @grid-outer-padding;
+	padding-left: @grid-outer-padding;
+
+	&-fluid {
+		padding-right: @grid-outer-padding;
+		padding-left: @grid-outer-padding;
+	}
+}

--- a/less/bootstrap-override/variables.less
+++ b/less/bootstrap-override/variables.less
@@ -231,6 +231,8 @@
 //
 //## Define your custom responsive grid.
 
+@grid-outer-padding: 20px; // use for row containers
+
 //** Number of columns in the grid.
 @grid-columns:              12;
 //** Padding between columns. Gets divided in half for the left and right.

--- a/less/fuelux-mctheme.less
+++ b/less/fuelux-mctheme.less
@@ -18,6 +18,7 @@
 @import "bootstrap-override/alerts.less";
 @import "bootstrap-override/close.less";
 @import "help.less";
+@import "bootstrap-override/grid.less";
 @import "bootstrap-override/dropdowns.less";
 @import "bootstrap-override/button-groups.less";
 @import "bootstrap-override/input-groups.less";


### PR DESCRIPTION
Row recreates a 5px negative margin. This makes the the outer margin of the page closer to the padding between columns

`.container` should only be used around `.row`.

Non-rows should use a custom "padding: 15px;" container to align with .container .row.

This is a side effect of all our panels having padding and aligning their borders instead of aligning their contents.

This change allows this:

![screen shot 2015-01-07 at 12 44 38 am](https://cloud.githubusercontent.com/assets/1290832/5641407/73b5ec44-9606-11e4-96a1-fb3bbc57004e.png)
