### PR TITLE
Remove container padding override

### DIFF
--- a/less/bootstrap-override/grid.less
+++ b/less/bootstrap-override/grid.less
@@ -1,13 +1,3 @@
 //
 // Grid
 // --------------------------------------------------
-
-.container {
-	padding-right: @grid-outer-padding;
-	padding-left: @grid-outer-padding;
-
-	&-fluid {
-		padding-right: @grid-outer-padding;
-		padding-left: @grid-outer-padding;
-	}
-}

--- a/less/bootstrap-override/panels.less
+++ b/less/bootstrap-override/panels.less
@@ -1,6 +1,7 @@
 //panel with tables
-@import "../fuelux-override/mixins";
 @import "../fuelux-override/variables";
+@import "../fuelux-override/mixins";
+
 .panel {
 	.table {
 		border: 0;

--- a/less/bootstrap-override/variables.less
+++ b/less/bootstrap-override/variables.less
@@ -231,8 +231,6 @@
 //
 //## Define your custom responsive grid.
 
-@grid-outer-padding: 20px; // use for row containers
-
 //** Number of columns in the grid.
 @grid-columns:              12;
 //** Padding between columns. Gets divided in half for the left and right.


### PR DESCRIPTION
Reverts back to Bootstrap default, so not to mess with grid padding. Fixes #118.