### PR TITLE
Selectlist auto resize - mctheme overwrites the default padding of the label...with the change of the caret to the right causes overlapping. -This change fixes that and adds required padding.

### DIFF
--- a/less/fuelux-override/selectlist.less
+++ b/less/fuelux-override/selectlist.less
@@ -13,4 +13,10 @@
 			}
 		}
 	}
+	&[data-resize="auto"] {
+		.selected-label {
+			padding-right: 10px;
+		}
+
+	}
 }


### PR DESCRIPTION
Selectlist auto resize
- mctheme overwrites the default padding of the label...with the change of the caret to the right causes overlapping. -This change fixes that and adds required padding.