### PR TITLE
adjusted the width of the .icon-folder class so that the folder icon displays without an extra line of pixels on the right side

### DIFF
--- a/less/fuelux-override/tree.less
+++ b/less/fuelux-override/tree.less
@@ -46,7 +46,7 @@
 		margin-right: 4px;
 		.sprite(-96px, -2px);
 		height: 12px;
-		width: 17px;
+		width: 16px;
 	}
 
 	// SELECTED - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Seeing this in my app: 
![screen shot 2015-01-21 at 11 15 45 am](https://cloud.githubusercontent.com/assets/1205242/5839837/1760117c-a15f-11e4-8f23-63f8d9c72344.png)
