### PR TITLE
Selectlist auto resize

### DIFF
--- a/less/fuelux-override/selectlist.less
+++ b/less/fuelux-override/selectlist.less
@@ -14,9 +14,12 @@
 		}
 	}
 	&[data-resize="auto"] {
-		.selected-label {
-			padding-right: 10px;
+		.btn{
+			&.dropdown-toggle {
+				.selected-label {
+					padding-right: 10px;
+				}
+			}
 		}
-
 	}
 }


### PR DESCRIPTION
- mctheme overwrites the default padding of the label...with the change of the caret to the right causes overlapping. -This change fixes that and adds required padding.