### PR TITLE
Switch Heroku to grunt dist and serve for edge server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,7 +77,7 @@ module.exports = function (grunt) {
 			server: {
 				options: {
 					hostname: '*',
-					port: 8000,
+					port: process.env.PORT || 8000,
 					useAvailablePort: true	// don't be greedy with your ports
 				}
 			},

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node www/server.js
+web: grunt dist && node www/server.js

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ fuelux-mctheme/
 
 Have a bug or a feature request? Please first review the [open issues](https://github.com/ExactTarget/fuelux-mctheme/issues), then search for existing and closed issues. If your problem or idea is not addressed yet, [please open a new issue](https://github.com/ExactTarget/fuelux-mctheme/issues/new). The issue may be a bug in Bootstrap or Fuel UX. If you think it is, please post in the respective repository.
 
+## Edge servers
+
+A build of master is available at `https://fuelux-mctheme.herokuapp.com/dist/css/fuelux-mctheme.css`. 
+
+_These files should never be used in production and may not have been fully tested._
+
+To create your own edge server, setup a github web hook on Heroku for this repository and put the app into development mode with `heroku config:set NPM_CONFIG_PRODUCTION=false`.
+
+
 ##Philosophy and authors
 
 ### The Fuel UX Philosophy


### PR DESCRIPTION
Switches Heroku process to `grunt dist && node www/server.js` (connect) instead of node and runs dist on deploy/install. This requires all the devDependencies to be installed. To do this, the app needs:

`heroku config:set NPM_CONFIG_PRODUCTION=false`

In conclusion, this allows these to be an automatic "edge server" without any `dist bump` commits.
`https://fuelux-mctheme.herokuapp.com/dist/css/fuelux-mctheme.css`