### PR TITLE
Gh157   create a grunt serve dev task that does not change files in dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,10 @@ validation-status.json
 # Editors / IDEs
 .idea
 
-
-
-
 # Temp file created in the LESS build
 less/fuelux-override-no-namespace.less
 
+
+# dev-specific fils related to serve-dev task
+examples/*/*-dev.html
+dist-dev/


### PR DESCRIPTION
## Purpose
Allow serving the project in such a way that it does not overwrite the .css files in the `/dist/` directory.


## Overview

Currently, running `grunt serve` calls the `watch:full` task, which will call `distcss` when any .less files are changed, which will then overwrite the .css files in the `/dist/` directory — changes which are not to be checked into the repository.

The upshot is that simply running the server can change files that should not be checked in, and the risk that such changes _will_ inadvertently be checked in is, therefore, unsuitably high.


## The Change Proposed

This change adds some "dev-specific" tasks to Gruntfile.js.

A new `serve-dev` task is added that calls, `connect:server`, `watch:dev`, and, `shell:syncDistWithMaster`.

## watch:dev

```
dev: {
	files: ['less/**'],
	options: {
		livereload: isLivereloadEnabled
	},
	tasks: ['distcssdev']
}
```

`watch:dev` is essentially identical to `watch:full` except that it calls the new task `distcssdev` instead of `distcss`.

## distcssdev

```
grunt.registerTask('distcssdev', ['less:fuelux-mctheme-dev', 'replace:imgpathsdev']);
```

`distcssdev` calls "dev-specific" versions of the less build and the image paths replacement.


## less:fuelux-mctheme-dev

```
'fuelux-mctheme-dev': {
	options: {
		strictMath: true,
		sourceMap: true,
		outputSourceFiles: true,
		sourceMapURL: '<%= pkg.name %>.css.map',
		sourceMapFilename: 'dist-dev/css/<%= pkg.name %>.css.map'
	},
	files: {
		'dist-dev/css/fuelux-mctheme.css': 'less/fuelux-mctheme.less'
	}
},
```

`less:fuelux-mctheme-dev` is essentially identical to `less:fuelux-mctheme`, except the results of the less build go in a new `/dist-dev/` directory instead of into `/dist/`.


## replace:imgpathsdev

```
imgpathsdev: {
	overwrite: true,
	replacements:[
		{
			from: "'../../img",
			to: "'../img"
		}
	],
	src: [
		'dist-dev/css/fuelux-mctheme.css',
		'dist-dev/css/fuelux-mctheme.css.map'
	]
}
```

`replace:imgpathsdev` is essentially identical to `replace:imgpaths` except that it operates on the .css files in `/dist-dev/` instead of in `/dev/`.


## shell:syncDistWithMaster

```
syncDistWithMaster: {
	command: 'git checkout master -- dist/'
}
```

`shell:syncDistWithMaster` ensures that the files in `/dist/` match what is in `#master`, which is what the person running any of the `serve-dev` stuff wishes.


## Changes to .gitignore

```
# dev-specific fils related to serve-dev task
examples/*/*-dev.html
dist-dev/
```

Adds the files created by the new dev tasks to `.gitignore`, as well as a helpful rule for any `*-dev.html` files that get created in `examples/` that a developer could use to test files in the `/dist-dev/` directory.
