### PR TITLE
Remove 2 step LESS build process, add .fuelux wrapper to appropriate files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -205,6 +205,7 @@ module.exports = function (grunt) {
 		},
 
 
+
 		less: {
 			dev: {
 				options: {
@@ -215,11 +216,7 @@ module.exports = function (grunt) {
 					sourceMapFilename: 'dist/css/<%= pkg.name %>-dev.css.map'
 				},
 				files: {
-					'dist/css/fuelux-mctheme-dev.css': 'less/fuelux-mctheme.less',
-					'dist/css/fuelux-override-dev.css': 'less/fuelux-override.less',
-					'less/fuelux-mctheme-no-namespace.less': 'less/fuelux-mctheme.less',
-					'less/fuelux-override-no-namespace.less': 'less/fuelux-override.less',
-					'dist/css/fuelux-mctheme-all-dev.css': 'less/fuelux-mctheme-namespace.less'
+					'dist/css/fuelux-mctheme-dev.css': 'less/fuelux-mctheme.less'
 				}
 			},
 			dist: {
@@ -231,9 +228,7 @@ module.exports = function (grunt) {
 					sourceMapFilename: 'dist/css/<%= pkg.name %>.css.map'
 				},
 				files: {
-					'less/fuelux-mctheme-no-namespace.less': 'less/fuelux-mctheme.less',
-					'less/fuelux-override-no-namespace.less': 'less/fuelux-override.less',
-					'dist/css/fuelux-mctheme.css': 'less/fuelux-mctheme-namespace.less'
+					'dist/css/fuelux-mctheme.css': 'less/fuelux-mctheme.less'
 				}
 			},
 
@@ -326,14 +321,14 @@ module.exports = function (grunt) {
 		},
 		watch: {
 			full: {
-				files: ['Gruntfile.js', 'examples/**', 'less/**', '!less/fuelux-mctheme-no-namespace.less', '!less/fuelux-override-no-namespace.less'],
+				files: ['Gruntfile.js', 'examples/**', 'less/**'],
 				options: {
 					livereload: isLivereloadEnabled
 				},
 				tasks: ['distcss']
 			},
 			dev: {
-				files: ['Gruntfile.js', 'less/**', 'index.html', 'index-dev.html', '*-dev.html', 'dev.html', '!less/fuelux-mctheme-no-namespace.less'],
+				files: ['Gruntfile.js', 'less/**', 'index.html', 'index-dev.html', '*-dev.html', 'dev.html'],
 				options: {
 					livereload: isLivereloadEnabled
 				},
@@ -354,22 +349,11 @@ module.exports = function (grunt) {
 	// Icon creation task
 	grunt.registerTask('iconify', ['svgmin', 'grunticon']);
 
-
-	// Temporary LESS file deletion task
-	grunt.registerTask('delete-temp-less-file', 'Delete the temporary LESS file created during the build process', function () {
-		var options = {
-			force: true
-		};
-		grunt.file.delete('less/fuelux-mctheme-no-namespace.less', options);
-		grunt.file.delete('less/fuelux-override-no-namespace.less', options);
-	});
-
-
 	// CSS distribution task
-	grunt.registerTask('distcss', 'Compile LESS into the dist CSS', ['less:dist', 'delete-temp-less-file', 'replace:imgpaths', 'less:minify', 'usebanner']);
+	grunt.registerTask('distcss', 'Compile LESS into the dist CSS', ['less:dist', 'replace:imgpaths', 'less:minify', 'usebanner']);
 
 	// CSS dev distribution task
-	grunt.registerTask('distcssdev', 'Compile LESS into the dev CSS', ['less:dev', 'delete-temp-less-file']);
+	grunt.registerTask('distcssdev', 'Compile LESS into the dev CSS', ['less:dev']);
 
 	// ZIP distribution task
 	grunt.registerTask('distzip', ['copy:zipsrc', 'compress', 'clean:zipsrc']);

--- a/less/fuelux-mctheme-namespace.less
+++ b/less/fuelux-mctheme-namespace.less
@@ -1,5 +1,0 @@
-// Fuel UX override
-@import "fuelux-mctheme-no-namespace.less";
-.fuelux {
-	@import "fuelux-override-no-namespace.less";
-}

--- a/less/fuelux-mctheme.less
+++ b/less/fuelux-mctheme.less
@@ -12,4 +12,4 @@
 @import "bootstrap-override.less";
 
 // Fuel UX override
-// @import "fuelux-override.less";
+@import "fuelux-override.less";

--- a/less/fuelux-override/checkbox-no-js.less
+++ b/less/fuelux-override/checkbox-no-js.less
@@ -4,7 +4,7 @@
 }
 
 
-.checkbox, .checkbox-inline {
+.fuelux .checkbox, .fuelux .checkbox-inline {
 	
 	input[type="checkbox"]:not(.sr-only) {
 		& ~ label {

--- a/less/fuelux-override/checkbox.less
+++ b/less/fuelux-override/checkbox.less
@@ -24,7 +24,7 @@
 }
 
 
-.checkbox {
+.fuelux .checkbox {
 
 	&.highlight {
 		& label.checkbox-custom {
@@ -35,16 +35,12 @@
 
 
 
-.checkbox-custom {
+.fuelux .checkbox-custom {
 	line-height: 20px;
 
 	padding-left: @checkbox-padding-left;
 
 	.checkbox-before;
-
-	label& {
-		margin-bottom: 5px;
-	}
 
 	&:hover {
 		.checkbox-before;
@@ -107,4 +103,8 @@
 			position: absolute;
 		}
 	}
+}
+
+.fuelux label.checkbox-custom {
+  margin-bottom: 5px;
 }

--- a/less/fuelux-override/combobox.less
+++ b/less/fuelux-override/combobox.less
@@ -1,4 +1,4 @@
-.combobox {
+.fuelux .combobox {
 	background: #fff;
 	border: solid 1px @combobox-border-default;
 	border-radius: 4px;

--- a/less/fuelux-override/datepicker.less
+++ b/less/fuelux-override/datepicker.less
@@ -1,4 +1,4 @@
-.datepicker {
+.fuelux .datepicker {
 	background: #fff;
 
 	&:hover {
@@ -110,6 +110,11 @@
 					&.current-day {
 						button {
 							background: #E6E6E6;
+							// border: 1px solid #999;
+						}
+
+						span {
+							border-radius: 0px;
 							border: 1px solid #999;
 						}
 
@@ -119,6 +124,12 @@
 								border: none;
 								-webkit-box-shadow: 1px 2px 2px 0 rgba(0, 0, 0, 0.1) inset;
 								box-shadow: 1px 2px 2px 0 rgba(0, 0, 0, 0.1) inset;
+							}
+						}
+
+						&.selected:hover {
+							button {
+								background: @blue-slate;
 							}
 						}
 					}
@@ -140,10 +151,13 @@
 
 					&.selected {
 						button, button:hover {
-							background: @blue-slate;
+							background: @blue-sky;
 							border: none;
 							-webkit-box-shadow: 1px 2px 2px 0 rgba(0, 0, 0, 0.1) inset;
 							box-shadow: 1px 2px 2px 0 rgba(0, 0, 0, 0.1) inset;
+						}
+						button:hover {
+							background: @blue-slate;
 						}
 
 						span, span:hover {

--- a/less/fuelux-override/forms.less
+++ b/less/fuelux-override/forms.less
@@ -4,7 +4,30 @@
 	}
 }
 
-.radio, .checkbox {
+
+.fuelux label.radio:hover,
+.fuelux label.checkbox:hover,
+.fuelux label.radio-inline:hover,
+.fuelux label.checkbox-inline:hover,
+.fuelux .input-label.radio:hover,
+.fuelux .input-label.checkbox:hover,
+.fuelux .input-label.radio-inline:hover,
+.fuelux .input-label.checkbox-inline:hover {
+		.labelHover;
+}
+
+.fuelux label.radio,
+.fuelux label.checkbox,
+.fuelux label.radio-inline,
+.fuelux label.checkbox-inline {
+	cursor: pointer;
+	font-weight: normal;
+	font-size: 12px;
+	.labelHover;
+}
+
+
+.fuelux .radio, .fuelux .checkbox {
 	// outline: 1px solid limegreen;
 	// position: relative;
 	// left: -4px;
@@ -27,11 +50,11 @@
 		// Sometimes the wrapping containter is a div with .checkbox or .radio, and has a label within it.
 		// Sometimes the label itself is the wrapping container, and has .checkbox or .radio on it.
 		// The use of the amperstand "parent selector" here allows us to cover many scenarios at once, with terse, but elegant, code.
-		label&, .input-label&, & label, & .input-label {
+		& label, & .input-label {
 			.labelHover;
 		}
 		
-		label, .input-label, label& {
+		label, .input-label {
 			cursor: pointer;
 			font-weight: normal;
 			font-size: 12px;
@@ -178,11 +201,6 @@
 		}
 	}
 
-
-	& + & input:not(.sr-only) ~ label {
-		top: 1px;
-	}
-
 	&.highlight {
 		input:not(.sr-only) {
 			& ~ label {
@@ -207,4 +225,12 @@
 
 
 
+}
+
+
+.fuelux .radio + .radio input:not(.sr-only) ~ label,
+.fuelux .radio + .checkbox input:not(.sr-only) ~ label,
+.fuelux .checkbox + .radio input:not(.sr-only) ~ label,
+.fuelux .checkbox + .checkbox input:not(.sr-only) ~ label {
+	top: 1px;
 }

--- a/less/fuelux-override/loader.less
+++ b/less/fuelux-override/loader.less
@@ -1,3 +1,3 @@
-.loader {
+.fuelux .loader {
 	color: @loader-color;
 }

--- a/less/fuelux-override/pillbox.less
+++ b/less/fuelux-override/pillbox.less
@@ -1,4 +1,4 @@
-.pillbox {
+.fuelux .pillbox {
 	border: 1px solid @border-color;
 	&[data-readonly] {
 		> .pill-group > .pill {

--- a/less/fuelux-override/placard.less
+++ b/less/fuelux-override/placard.less
@@ -1,4 +1,4 @@
-.placard {
+.fuelux .placard {
 	&-cancel {
 		color: @blue-steel;
 		font-size: 10px;
@@ -18,6 +18,6 @@
 	}
 }
 
-.placard-popup {
+.fuelux .placard-popup {
 	background-color: @blue-slate;
 }

--- a/less/fuelux-override/radio-no-js.less
+++ b/less/fuelux-override/radio-no-js.less
@@ -4,7 +4,7 @@
 }
 
 
-.radio, .radio-inline {
+.fuelux .radio, .fuelux .radio-inline {
 	
 	input[type="radio"]:not(.sr-only) {
 
@@ -91,32 +91,26 @@
 }
 
 
-.radio {
-	& + & input:not(.sr-only) ~ label {
+.fuelux .radio {
+	& + .radio input:not(.sr-only) ~ label {
 		top: 0px;
 	}
-	& + & {
+	& + .radio {
 		label.radio-custom {
 			margin-top: 5px;
 		}
 	}
 	&.highlight {
-		& + & {
+		& + .radio.highlight {
 			margin-top: -5px;
 		}
-		input:not(.sr-only) {
-			& ~ label {
-				left: -7px;
-			}
+		input:not(.sr-only)  ~ label {
+			left: -7px;
 		}
 	}
-	&-inline {
-		&.highlight {
-			input:not(.sr-only) {
-				& ~ label {
-					left: -3px;
-				}
-			}
+	&-inline.highlight {
+		input:not(.sr-only) ~ label {
+			left: -3px;
 		}
 	}
 }

--- a/less/fuelux-override/radio.less
+++ b/less/fuelux-override/radio.less
@@ -39,7 +39,7 @@
 
 
 
-.radio-custom {
+.fuelux .radio-custom {
 	line-height: 20px;
 
 	padding-left: @radio-button-padding-left;
@@ -99,19 +99,20 @@
 		}
 	}
 
-	label&.radio-inline, &.radio-inline {
+}
 
-		@form-elements-padding: unit( ((@radio-button-width-value + ((@radio-button-width-value / 3) * 3))), px );
+.fuelux label.radio-custom.radio-inline, .radio-custom.radio-inline {
 
+	@form-elements-padding: unit( ((@radio-button-width-value + ((@radio-button-width-value / 3) * 3))), px );
+
+	padding-left: @form-elements-padding;
+
+
+	&.highlight {
+		@form-elements-padding: unit( ((@radio-button-width-value + ((@radio-button-width-value / 3) * 4))), px );
 		padding-left: @form-elements-padding;
-
-
-		&.highlight {
-			@form-elements-padding: unit( ((@radio-button-width-value + ((@radio-button-width-value / 3) * 4))), px );
-			padding-left: @form-elements-padding;
-			&:before {
-				top: 6px;
-			}
+		&:before {
+			top: 6px;
 		}
 	}
 }

--- a/less/fuelux-override/repeater-list.less
+++ b/less/fuelux-override/repeater-list.less
@@ -1,4 +1,4 @@
-.repeater-list {
+.fuelux .repeater-list {
 	.table {
 		border: none;
 

--- a/less/fuelux-override/repeater-thumbnail.less
+++ b/less/fuelux-override/repeater-thumbnail.less
@@ -1,4 +1,4 @@
-.repeater-thumbnail-cont {
+.fuelux .repeater-thumbnail-cont {
 	.thumbnail {
 		&.selected {
 			background:@blue-slate;

--- a/less/fuelux-override/repeater.less
+++ b/less/fuelux-override/repeater.less
@@ -1,4 +1,4 @@
-.repeater {
+.fuelux .repeater {
 
 
 	&-filters {

--- a/less/fuelux-override/scheduler.less
+++ b/less/fuelux-override/scheduler.less
@@ -1,4 +1,4 @@
-.scheduler {
+.fuelux .scheduler {
 	
 	.form-group {
 		margin-left: 0px;

--- a/less/fuelux-override/search.less
+++ b/less/fuelux-override/search.less
@@ -1,4 +1,4 @@
-.search {
+.fuelux .search {
 	background: #fff;
 	border: 1px solid #ccc;
 	border-radius: 4px;

--- a/less/fuelux-override/selectlist.less
+++ b/less/fuelux-override/selectlist.less
@@ -3,7 +3,7 @@
 @mctheme-selectlist-horizontal-padding: 5px;
 @mctheme-selectlist-caret-width: 4px;
 
-.selectlist {
+.fuelux .selectlist {
 	.btn {
 		&.dropdown-toggle {
 			background: linear-gradient(#FFFFFF, @gray93);

--- a/less/fuelux-override/spinbox.less
+++ b/less/fuelux-override/spinbox.less
@@ -1,4 +1,4 @@
-.spinbox {
+.fuelux .spinbox {
 	border: solid 1px #bbbbbb;
 	border-radius: 4px;
 	background: #fff;

--- a/less/fuelux-override/tree.less
+++ b/less/fuelux-override/tree.less
@@ -22,7 +22,7 @@
 }
 
 
-.tree {
+.fuelux .tree {
 	border-color: @border-color;
 	padding: 10px 0;
 

--- a/less/fuelux-override/wizard.less
+++ b/less/fuelux-override/wizard.less
@@ -1,4 +1,4 @@
-.wizard {
+.fuelux .wizard {
 	position: relative;
 
 	.actions {

--- a/less/icons.less
+++ b/less/icons.less
@@ -1,5 +1,14 @@
 @import "icons/icons-svg.less";
 
+.btn-lg .fuelux-icon {
+	width: 20px;
+	height: 20px;
+}
+
+.btn-sm .fuelux-icon {
+	width: 13px;
+	height: 13px;
+}
 
 .mcthemeicon-breadcrumb {
 	width: 10px;

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -1,25 +1,20 @@
-.fuelux-icon {
+.fuelux-icon() {
 	background-size: cover;
 	display: inline-block;
 	width: 16px;
 	height: 16px;
-	button:hover > & {
+
+	button:hover > .fuelux-icon {
 	}
+
 	&:before {
 		content: "";
 	}
 
-	.btn-lg & {
-		width: 20px;
-		height: 20px;
-	}
-
-	.btn-sm & {
-		width: 13px;
-		height: 13px;
-	}
 
 }
+
+
 
 
 // Button sizes


### PR DESCRIPTION
Modify LESS build process and .less files so the .fuelux wrapper is applied in the included files rather than with a janky two-stage build processs. This way also preserves the integrity of LESS's & parent selector. Win-win. Fixes #235