### PR TITLE
Breadcrumb help icon fix

### DIFF
--- a/less/bootstrap-override/breadcrumb.less
+++ b/less/bootstrap-override/breadcrumb.less
@@ -1,28 +1,30 @@
+@import "icons/icons-svg.less";
+
 .breadcrumb {
 	padding: 8px 15px;
 	margin-bottom: 20px;
 	list-style: none;
 	background-color: transparent;
 	border-radius: 0;
-	> li + li:before, > li:first-child:before {
-		.sprite(-210px, -0px);
-		content: '';
-		top: -2px;
-		position: relative;
-		margin: 0 2px;
 
+	> li + li:before, > li:first-child:before {
+		.fuelux-icon;
+		.fuelux-icon-breadcrumb;
+		content: '';
+		margin: 0px 2px -3px 0px;
+		width: 5px;
+		background-size: 25px 19px;
 	}
+
 	> li:first-child:before {
-		padding: 1px 16px;
-		top: 0;
+		margin: 0px 7px -7px 0px;
+		background-size: 22px 22px;
+		height: 22px;
+		width: 22px;
 	}
+
 	.active {
 		color: #000000;
 	}
-}
 
-@media(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-	> li + li:before, > li:first-child:before {
-		.sprite2x();
-	}
 }

--- a/less/help.less
+++ b/less/help.less
@@ -1,23 +1,19 @@
+@import "icons/icons-svg.less";
+
 .fueluxicon-question-mark, .fuel-help {
 	display: inline-block;
-	.sprite(-144px, -16px);
+	.fuelux-icon;
+	.fuelux-icon-help;
 	width: 13px;
 	height: 13px;
 	cursor: pointer;
 	border: 0;
 	padding: 0;
+	outline: 0;
 
-	&:hover {
-		background-position: -160px -16px;
-	}
-}
-
-@media(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-	.fuel-help,
-	.fuel-help:hover,
-	.fueluxicon-question-mark,
-	.fueluxicon-question-mark:hover
-	{
-		.sprite2x();
+	&:hover, &:focus {
+		.fuelux-icon-help-hover;
+		width: 13px;
+		height: 13px;
 	}
 }

--- a/less/icons.less
+++ b/less/icons.less
@@ -1,5 +1,3 @@
-@import "icons/icons-svg.less";
-
 .btn-lg .fuelux-icon {
 	width: 20px;
 	height: 20px;
@@ -9,20 +7,6 @@
 	width: 13px;
 	height: 13px;
 }
-
-.mcthemeicon-breadcrumb {
-	width: 10px;
-	height: 12px;
-	display: inline-block;
-	.sprite(-210px, 0);
-}
-
-@media(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-	.mcthemeicon-breadcrumb {
-		.sprite2x();
-	}
-}
-
 
 // The columns configure icon has a little gear sticking out of it, making it need to be bigger than the other column type icons in a repeater toolbar, so that the columns box itself appears to be the same size. The margin-bottom is so that it aligns correctly, and it's container button is the same size as the rest of the buttons in the toolbar.
 .fuelux-icon.fuelux-icon-gridview-columns-configure {


### PR DESCRIPTION
Fixes #232 and #263.

@dkilgore @gdborton

Preview of output:

![new](https://cloud.githubusercontent.com/assets/1290832/7352341/f82ecb20-ecd8-11e4-9169-2e72ffb60444.png)

Ignore close icon. Image is cropped.

Old raster version of breadcrumb: 
![old](https://cloud.githubusercontent.com/assets/1290832/7352350/ffe9e124-ecd8-11e4-882f-7cf5b4a8e3f8.png)