### PR TITLE
Add all release tags to prompt menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ less/fuelux-mctheme-no-namespace.less
 # Temp file created in the LESS build
 less/icons/png/*.png
 
+# Upload settings shh!
+FUELUX_MCTHEME_CDN.yml
 
 # dev-specific fils related to serve-dev task
 examples/*/*-dev.html


### PR DESCRIPTION
Just like in the Fuel UX repo, this adds git commands to a release prompt menu.

![screen shot 2015-06-02 at 3 55 52 pm](https://cloud.githubusercontent.com/assets/1290832/7945611/dff8791a-093f-11e5-99c2-003e4453a595.png)