### PR TITLE
Increase specificity of wizard steps to override FUX 3.8

### DIFF
--- a/less/fuelux-override/wizard.less
+++ b/less/fuelux-override/wizard.less
@@ -26,7 +26,7 @@
 		}
 	}
 
-	.steps {
+	> ul.steps, > .steps-container > ul.steps {
 		background: #f4f5f6;
 		background-image: -webkit-linear-gradient(top, #fafafa, #eeeff1);
 		background-image: linear-gradient(to bottom, #fafafa, #eeeff1);


### PR DESCRIPTION
Our markup changes to wizard in Fuel UX 3.8 were causing an override in MCtheme. Fixes #300.