### PR TITLE
Remove use of `!important`

### DIFF
--- a/less/bootstrap-override/buttons.less
+++ b/less/bootstrap-override/buttons.less
@@ -261,7 +261,6 @@
 	color: @link-color;
 	cursor: pointer;
 	border-radius: 0;
-	outline: 0 !important;
 	padding: 0;
 	.box-shadow(none);
 

--- a/less/bootstrap-override/modals.less
+++ b/less/bootstrap-override/modals.less
@@ -36,14 +36,14 @@
 
 	.modal-footer .btn-default[data-dismiss=modal] {
 		float: left;
-		background: transparent !important;
+		background: transparent;
 		box-shadow: none;
 		border: none;
 		color: @brand-primary-medium;
 		padding-left: 0;
 
 		&:hover {
-			background: transparent !important;
+			background: transparent;
 		}
 	}
 }

--- a/less/fuelux-override/checkbox-no-js.less
+++ b/less/fuelux-override/checkbox-no-js.less
@@ -20,7 +20,7 @@
 				-webkit-appearance: inherit;
 				border: 0px solid transparent;
 				border-radius: 0;
-				content: "" !important;
+				content: "";
 				padding: 0;
 				position: relative;
 				// top: 2px;
@@ -45,7 +45,7 @@
 					-webkit-appearance: inherit;
 					border: 0px solid transparent;
 					border-radius: 0;
-					content: "" !important;
+					content: "";
 					padding: 0;
 					.fuelux-icon-checkbox-checked;
 					.checkbox-no-js-element-sizes;
@@ -60,7 +60,7 @@
 					-webkit-appearance: inherit;
 					border: 0px solid transparent;
 					border-radius: 0;
-					content: "" !important;
+					content: "";
 					padding: 0;
 					.fuelux-icon-checkbox-checked-hover;
 					.checkbox-no-js-element-sizes;

--- a/less/fuelux-override/checkbox.less
+++ b/less/fuelux-override/checkbox.less
@@ -19,7 +19,7 @@
 		border: 0px solid transparent;
 		border-radius: 0;
 		box-shadow: none;
-		content: "" !important;
+		content: "";
 		padding: 0;
 		outline: 0;
 	}

--- a/less/fuelux-override/forms.less
+++ b/less/fuelux-override/forms.less
@@ -167,8 +167,8 @@
 			&[disabled="disabled"] {
 				& ~ label, & ~ label:before {
 					color: @text-color;
-					opacity: 0.5 !important;
-					cursor: not-allowed !important;
+					opacity: 0.5;
+					cursor: not-allowed;
 				}
 			}
 

--- a/less/fuelux-override/radio-no-js.less
+++ b/less/fuelux-override/radio-no-js.less
@@ -20,7 +20,7 @@
 				-webkit-appearance: inherit;
 				border: 0px solid transparent;
 				border-radius: 0;
-				content: "" !important;
+				content: "";
 				padding: unit((@radio-button-width-value / 2), px);
 				top: 2px;
 				// margin-right: 2px;

--- a/less/fuelux-override/radio.less
+++ b/less/fuelux-override/radio.less
@@ -20,7 +20,7 @@
 		border: 0px solid transparent;
 		border-radius: 0;
 		box-shadow: none;
-		content: "" !important;
+		content: "";
 		padding: unit((@radio-button-width-value / 2), px);
 		top: 2px;
 	}

--- a/less/fuelux-override/tree.less
+++ b/less/fuelux-override/tree.less
@@ -15,7 +15,7 @@
 	-webkit-appearance: inherit;
 	border: 0px solid transparent;
 	border-radius: 0;
-	content: "" !important;
+	content: "";
 	padding: 12px 0 0;//has to be here instead of .tree-caret-sizes() because otherwise folder selection in FF messes up
 	background-position: 0px;
 	box-sizing: border-box;


### PR DESCRIPTION
Fixes #289 although I left the icon base style overrides to make sure they aren't bold/italic etc.