### PR TITLE
Align wizard example to wizard pattern

### DIFF
--- a/examples/fuelux/fuelux.html
+++ b/examples/fuelux/fuelux.html
@@ -2409,8 +2409,8 @@
 						</li>
 					</ul>
 					<div class="actions">
-						<button class="btn btn-default btn-prev"><span class="glyphicon glyphicon-arrow-left"></span>Prev</button>
-						<button class="btn btn-default btn-next" data-last="Complete">Next<span class="glyphicon glyphicon-arrow-right"></span>
+						<button class="btn btn-default btn-prev"><span class="glyphicon glyphicon-arrow-left"></span>Back</button>
+						<button class="btn btn-primary btn-next" data-last="Complete">Next<span class="glyphicon glyphicon-arrow-right"></span>
 						</button>
 					</div>
 					<div class="step-content">
@@ -2502,8 +2502,8 @@
 						</ul>
 						<div class="actions">
 							<button class="btn btn-default btn-prev">
-								<span class="glyphicon glyphicon-arrow-left"></span>Prev</button>
-							<button class="btn btn-default btn-next" data-last="Complete">Next
+								<span class="glyphicon glyphicon-arrow-left"></span>Back</button>
+							<button class="btn btn-primary btn-next" data-last="Complete">Next
 								<span class="glyphicon glyphicon-arrow-right"></span>
 							</button>
 						</div>

--- a/less/fuelux-override/wizard.less
+++ b/less/fuelux-override/wizard.less
@@ -26,6 +26,11 @@
 		}
 	}
 
+	.step-content {
+		padding: 10px 15px;
+		background-color: #ffffff;
+	}
+
 	> ul.steps, > .steps-container > ul.steps {
 		background: #f4f5f6;
 		background-image: -webkit-linear-gradient(top, #fafafa, #eeeff1);


### PR DESCRIPTION
Fixes #312.

Caveat: Visual padding cased by content's marget (not wizard)

@jamin-hall Please double check that this aligns.
<img width="917" alt="screen shot 2015-07-15 at 2 42 00 pm" src="https://cloud.githubusercontent.com/assets/1290832/8706796/b73126ee-2aff-11e5-86b1-e66e983c9d27.png">

- Content background should be white.
- Verify padding is correct.
- Verify Use of arrow with "next"
- Back/Next copy