### PR TITLE
Add wizard no-border variation

### DIFF
--- a/examples/bootstrap-javascript/bootstrap-javascript.html
+++ b/examples/bootstrap-javascript/bootstrap-javascript.html
@@ -6,6 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 	<link href="../../bower_components/bootstrap/dist/css/bootstrap.css" rel="stylesheet" type="text/css">
+	<link href="../../bower_components/fuelux/dist/css/fuelux.css" rel="stylesheet" type="text/css">
 	<link href="../../dist/css/fuelux-mctheme.css" rel="stylesheet" type="text/css"/>
 	<link href="bootstrap-javascript-examples.css" rel="stylesheet" type="text/css"/>
 
@@ -82,8 +83,58 @@
 									<span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
 								<h4 class="modal-title">Modal title</h4>
 							</div>
-							<div class="modal-body">
-								<p>One fine body&hellip;</p>
+							<div class="fuelux">
+
+								<div class="wizard no-border" data-initialize="wizard" id="myWizard">
+									<div class="steps-container">
+										<ul class="steps">
+											<li data-step="1"><span class="badge">1</span>Campaign<span class="chevron"></span>
+											</li>
+											<li class="active" data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span>
+											</li>
+											<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span>
+											</li>
+											<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span>
+											</li>
+											<li data-step="5" data-name="distep"><span class="badge">5</span>Send<span class="chevron"></span>
+											</li>
+										</ul>
+									</div>
+									<div class="actions">
+										<button class="btn btn-default btn-prev"><span class="glyphicon glyphicon-arrow-left"></span>Back</button>
+										<button class="btn btn-primary btn-next" data-last="Complete">Next<span class="glyphicon glyphicon-arrow-right"></span>
+										</button>
+									</div>
+									<div class="step-content">
+										<div class="step-pane active sample-pane" data-step="1">
+											<h4>Setup Campaign</h4>
+											<p>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic. Beetroot water spinach okra water chestnut ricebean pea catsear courgette.</p>
+											<p>Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress. Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke. Beetroot water spinach okra water chestnut ricebean pea catsear courgette.</p>
+										</div>
+										<div class="step-pane sample-pane" data-step="2">
+											<h4>Choose Recipients</h4>
+											<p>Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear garlic gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed kombu beetroot horseradish carrot squash brussels sprout chard. </p>
+											<p>Pea horseradish azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn fava bean mustard tigernut jÃ­cama green bean celtuce collard greens avocado quandong fennel gumbo black-eyed pea. Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra pea winter purslane coriander yarrow sweet pepper radish garlic brussels sprout groundnut summer purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo kakadu plum komatsuna black-eyed pea green bean zucchini gourd winter purslane silver beet rock melon radish asparagus spinach. </p>
+										</div>
+										<div class="step-pane sample-pane" data-step="3">
+											<h4>Design Template</h4>
+											<p>Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery. Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip. Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean earthnut pea sierra leone bologi leek soko chicory celtuce parsley jÃ­cama salsify. </p>
+											<p>Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear garlic gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed kombu beetroot horseradish carrot squash brussels sprout chard. </p>
+										</div>
+										<div class="step-pane sample-pane" data-step="4">
+											<h4>Preview Message</h4>
+											<p>Beetroot water spinach okra water chestnut ricebean pea catsear courgette summer purslane. Water spinach arugula pea tatsoi aubergine spring onion bush tomato kale radicchio turnip chicory salsify pea sprouts fava bean. Dandelion zucchini burdock yarrow chickpea dandelion sorrel courgette turnip greens tigernut soybean radish artichoke wattle seed endive groundnut broccoli arugula. Beetroot water spinach okra water chestnut ricebean pea catsear courgette.</p>
+											<p>Soko radicchio bunya nuts gram dulse silver beet parsnip napa cabbage lotus root sea lettuce brussels sprout cabbage. Catsear cauliflower garbanzo yarrow salsify chicory garlic bell pepper napa cabbage lettuce tomato kale arugula melon sierra leone bologi rutabaga tigernut. Sea lettuce gumbo grape kale kombu cauliflower salsify kohlrabi okra sea lettuce broccoli celery lotus root carrot winter purslane turnip greens garlic.</p>
+										</div>
+										<div class="step-pane sample-pane" data-step="5" data-name="distep">
+											<h4>Send Message</h4>
+											<p>Soko radicchio bunya nuts gram dulse silver beet parsnip napa cabbage lotus root sea lettuce brussels sprout cabbage. Catsear cauliflower garbanzo yarrow salsify chicory garlic bell pepper napa cabbage lettuce tomato kale arugula melon sierra leone bologi rutabaga tigernut.</p>
+											<p>Sea lettuce gumbo grape kale kombu cauliflower salsify kohlrabi okra sea lettuce broccoli celery lotus root carrot winter purslane turnip greens garlic. JÃ­cama garlic courgette coriander radicchio plantain scallion cauliflower fava bean desert raisin spring onion chicory bunya nuts. Sea lettuce water spinach gram fava bean leek dandelion silver beet eggplant bush tomato. </p>
+											<p>Pea horseradish azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn fava bean mustard tigernut jÃ­cama green bean celtuce collard greens avocado quandong fennel gumbo black-eyed pea. Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra pea winter purslane coriander yarrow sweet pepper radish garlic brussels sprout groundnut summer purslane earthnut pea tomato spring onion azuki bean gourd. </p>
+										</div>
+									</div>
+								</div>
+
 							</div>
 							<div class="modal-footer">
 								<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>

--- a/examples/fuelux/fuelux.html
+++ b/examples/fuelux/fuelux.html
@@ -2396,18 +2396,20 @@
 			<h2>Wizard</h2>
 			<div class="thin-box">
 				<div class="wizard" data-initialize="wizard" id="myWizard">
-					<ul class="steps">
-						<li data-step="1"><span class="badge">1</span>Campaign<span class="chevron"></span>
-						</li>
-						<li class="active" data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span>
-						</li>
-						<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span>
-						</li>
-						<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span>
-						</li>
-						<li data-step="5" data-name="distep"><span class="badge">5</span>Send<span class="chevron"></span>
-						</li>
-					</ul>
+					<div class="steps-container">
+						<ul class="steps">
+							<li data-step="1"><span class="badge">1</span>Campaign<span class="chevron"></span>
+							</li>
+							<li class="active" data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span>
+							</li>
+							<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span>
+							</li>
+							<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span>
+							</li>
+							<li data-step="5" data-name="distep"><span class="badge">5</span>Send<span class="chevron"></span>
+							</li>
+						</ul>
+					</div>
 					<div class="actions">
 						<button class="btn btn-default btn-prev"><span class="glyphicon glyphicon-arrow-left"></span>Prev</button>
 						<button class="btn btn-default btn-next" data-last="Complete">Next<span class="glyphicon glyphicon-arrow-right"></span>
@@ -2420,7 +2422,7 @@
 							<p>Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress. Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke. Beetroot water spinach okra water chestnut ricebean pea catsear courgette.</p>
 							<p>Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato. Dandelion cucumber earthnut pea peanut soko zucchini. </p>
 						</div>
-						<div class="step-pane sample-pane alert-info alert" data-step="2">
+						<div class="step-pane sample-pane" data-step="2">
 							<h4>Choose Recipients</h4>
 							<p>Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear garlic gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed kombu beetroot horseradish carrot squash brussels sprout chard. </p>
 							<p>Pea horseradish azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn fava bean mustard tigernut jÃ­cama green bean celtuce collard greens avocado quandong fennel gumbo black-eyed pea. Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra pea winter purslane coriander yarrow sweet pepper radish garlic brussels sprout groundnut summer purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo kakadu plum komatsuna black-eyed pea green bean zucchini gourd winter purslane silver beet rock melon radish asparagus spinach. </p>
@@ -2457,49 +2459,105 @@
 				<button type="button" class="btn btn-default" id="btnWizardRemoveStep">remove step (preview)</button>
 				<button type="button" class="btn btn-default" id="btnWizardDestroy">destroy and append</button>
 			</div>
+
+			<section id="wizard-no-border">
+				<h2>Wizard (No border)</h2>
+				<div class="thin-box">
+					<div class="wizard no-border" data-initialize="wizard" id="myWizard">
+						<div class="steps-container">
+							<ul class="steps">
+								<li data-step="1"><span class="badge">1</span>Campaign<span class="chevron"></span>
+								</li>
+								<li class="active" data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span>
+								</li>
+								<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span>
+								</li>
+								<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span>
+								</li>
+								<li data-step="5" data-name="distep"><span class="badge">5</span>Send<span class="chevron"></span>
+								</li>
+							</ul>
+						</div>
+						<div class="actions">
+							<button class="btn btn-default btn-prev"><span class="glyphicon glyphicon-arrow-left"></span>Back</button>
+							<button class="btn btn-primary btn-next" data-last="Complete">Next<span class="glyphicon glyphicon-arrow-right"></span>
+							</button>
+						</div>
+						<div class="step-content">
+							<div class="step-pane active sample-pane" data-step="1">
+								<h4>Setup Campaign</h4>
+								<p>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic. Beetroot water spinach okra water chestnut ricebean pea catsear courgette.</p>
+								<p>Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress. Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke. Beetroot water spinach okra water chestnut ricebean pea catsear courgette.</p>
+							</div>
+							<div class="step-pane sample-pane" data-step="2">
+								<h4>Choose Recipients</h4>
+								<p>Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear garlic gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed kombu beetroot horseradish carrot squash brussels sprout chard. </p>
+								<p>Pea horseradish azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn fava bean mustard tigernut jÃ­cama green bean celtuce collard greens avocado quandong fennel gumbo black-eyed pea. Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra pea winter purslane coriander yarrow sweet pepper radish garlic brussels sprout groundnut summer purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo kakadu plum komatsuna black-eyed pea green bean zucchini gourd winter purslane silver beet rock melon radish asparagus spinach. </p>
+							</div>
+							<div class="step-pane sample-pane" data-step="3">
+								<h4>Design Template</h4>
+								<p>Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery. Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip. Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean earthnut pea sierra leone bologi leek soko chicory celtuce parsley jÃ­cama salsify. </p>
+								<p>Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear garlic gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed kombu beetroot horseradish carrot squash brussels sprout chard. </p>
+							</div>
+							<div class="step-pane sample-pane" data-step="4">
+								<h4>Preview Message</h4>
+								<p>Beetroot water spinach okra water chestnut ricebean pea catsear courgette summer purslane. Water spinach arugula pea tatsoi aubergine spring onion bush tomato kale radicchio turnip chicory salsify pea sprouts fava bean. Dandelion zucchini burdock yarrow chickpea dandelion sorrel courgette turnip greens tigernut soybean radish artichoke wattle seed endive groundnut broccoli arugula. Beetroot water spinach okra water chestnut ricebean pea catsear courgette.</p>
+								<p>Soko radicchio bunya nuts gram dulse silver beet parsnip napa cabbage lotus root sea lettuce brussels sprout cabbage. Catsear cauliflower garbanzo yarrow salsify chicory garlic bell pepper napa cabbage lettuce tomato kale arugula melon sierra leone bologi rutabaga tigernut. Sea lettuce gumbo grape kale kombu cauliflower salsify kohlrabi okra sea lettuce broccoli celery lotus root carrot winter purslane turnip greens garlic.</p>
+							</div>
+							<div class="step-pane sample-pane" data-step="5" data-name="distep">
+								<h4>Send Message</h4>
+								<p>Soko radicchio bunya nuts gram dulse silver beet parsnip napa cabbage lotus root sea lettuce brussels sprout cabbage. Catsear cauliflower garbanzo yarrow salsify chicory garlic bell pepper napa cabbage lettuce tomato kale arugula melon sierra leone bologi rutabaga tigernut.</p>
+								<p>Sea lettuce gumbo grape kale kombu cauliflower salsify kohlrabi okra sea lettuce broccoli celery lotus root carrot winter purslane turnip greens garlic. JÃ­cama garlic courgette coriander radicchio plantain scallion cauliflower fava bean desert raisin spring onion chicory bunya nuts. Sea lettuce water spinach gram fava bean leek dandelion silver beet eggplant bush tomato. </p>
+								<p>Pea horseradish azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn fava bean mustard tigernut jÃ­cama green bean celtuce collard greens avocado quandong fennel gumbo black-eyed pea. Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra pea winter purslane coriander yarrow sweet pepper radish garlic brussels sprout groundnut summer purslane earthnut pea tomato spring onion azuki bean gourd. </p>
+							</div>
+						</div>
+					</div>
+				</div>
 		
 			<section id="wizard-2">
 				<h2>Wizard (shows secondary text in nav)</h2>
 				<div class="thin-box">
 					<div class="wizard" data-initialize="wizard" id="myWizard">
-						<ul class="steps">
-							<li data-step="1">
-								<span class="badge">1</span>
-								<div class="has-secondary-text">
-									<h4>
-										Select Campaign
-									</h4>
-									<small>
-										Outbound
-									</small>
-								</div>
-								<span class="chevron"></span>
-							</li>
-							<li class="active" data-step="2">
-								<span class="badge">2</span>Recipients
-								<span class="chevron"></span>
-							</li>
-							<li data-step="3">
-								<span class="badge">3</span>
-								<div class="has-secondary-text">
-									<h4>
-										Select Template
-									</h4>
-									<small>
-										Custom Design
-									</small>
-								</div>
-								<span class="chevron"></span>
-							</li>
-							<li data-step="4">
-								<span class="badge">4</span>Preview
-								<span class="chevron"></span>
-							</li>
-							<li data-step="5" data-name="distep">
-								<span class="badge">5</span>Send
-								<span class="chevron"></span>
-							</li>
-						</ul>
+						<div class="steps-container">
+							<ul class="steps">
+								<li data-step="1">
+									<span class="badge">1</span>
+									<div class="has-secondary-text">
+										<h4>
+											Select Campaign
+										</h4>
+										<small>
+											Outbound
+										</small>
+									</div>
+									<span class="chevron"></span>
+								</li>
+								<li class="active" data-step="2">
+									<span class="badge">2</span>Recipients
+									<span class="chevron"></span>
+								</li>
+								<li data-step="3">
+									<span class="badge">3</span>
+									<div class="has-secondary-text">
+										<h4>
+											Select Template
+										</h4>
+										<small>
+											Custom Design
+										</small>
+									</div>
+									<span class="chevron"></span>
+								</li>
+								<li data-step="4">
+									<span class="badge">4</span>Preview
+									<span class="chevron"></span>
+								</li>
+								<li data-step="5" data-name="distep">
+									<span class="badge">5</span>Send
+									<span class="chevron"></span>
+								</li>
+							</ul>
+						</div>
 						<div class="actions">
 							<button class="btn btn-default btn-prev">
 								<span class="glyphicon glyphicon-arrow-left"></span>Prev</button>

--- a/less/fuelux-override/wizard.less
+++ b/less/fuelux-override/wizard.less
@@ -1,6 +1,11 @@
 .fuelux .wizard {
 	position: relative;
 
+	&.no-border {
+		border-radius: 0;
+		border: 0;
+	}
+
 	.actions {
 		background: #f4f5f6;
 		background-image: -webkit-linear-gradient(top, #fafafa, #eeeff1);


### PR DESCRIPTION
Adds example to mctheme's fuelux example page

This allows wizards to be present in a modal without extra borders or rounded corners.

@jamin-hall please approve.

![screen shot 2015-07-15 at 4 15 04 pm](https://cloud.githubusercontent.com/assets/1290832/8708933/05afbbe8-2b0d-11e5-8554-cb4a79820afa.png)
