### PR TITLE
hacky-fix for fuelux.min.css overwriting type styles in fuelux-mctheme.min.css

### DIFF
--- a/less/bootstrap-override/type.less
+++ b/less/bootstrap-override/type.less
@@ -1,115 +1,117 @@
-body{
-	font-family: @font-family-base;
-	color: @gray13;
-	font-size: @font-size-base;
-	line-height: @line-height-base;
-}
-
-.title-form, .title-header-page, .title-table {
-	line-height: @line-height-base;
-
-	small,
-	.small {
-		font-weight: normal;
-		line-height: 1;
-		color: @gray47;
-		font-size: 65%;
+.fuelux {
+	body{
+		font-family: @font-family-base;
+		color: @gray13;
+		font-size: @font-size-base;
+		line-height: @line-height-base;
 	}
-}
 
-.title-table { font-size: @font-size-h2; }
+	.title-form, .title-header-page, .title-table {
+		line-height: @line-height-base;
 
-.title-form { font-size: @font-size-h3; }
+		small,
+		.small {
+			font-weight: normal;
+			line-height: 1;
+			color: @gray47;
+			font-size: 65%;
+		}
+	}
 
-// Page header
-// -------------------------
-.page-header {
-	font-size: @font-size-h1;
-	margin-top: 10px;
-	border-bottom: none;
-	margin-bottom: 0;
+	.title-table { font-size: @font-size-h2; }
 
-	h1 {
-		line-height: 30px;	// matches create button height
-		margin-top: 0;
+	.title-form { font-size: @font-size-h3; }
+
+	// Page header
+	// -------------------------
+	.page-header {
+		font-size: @font-size-h1;
+		margin-top: 10px;
+		border-bottom: none;
 		margin-bottom: 0;
+
+		h1 {
+			line-height: 30px;	// matches create button height
+			margin-top: 0;
+			margin-bottom: 0;
+		}
+
+		// create button, etc.
+		& > :last-of-type:not(:only-of-type) {
+			text-align: right
+		}
+
 	}
 
-	// create button, etc.
-	& > :last-of-type:not(:only-of-type) {
-		text-align: right
+	p {
+		font-size: @font-size-base;
+
+		&.support-text{
+			color: @gray40;
+		}
+
+		&.hint-text{
+			color: @gray60;
+		}
+
+		&.disabled-text{
+			color: @gray67;
+		}
 	}
 
-}
+	h1, .h1 { font-size: @font-size-h1; }
+	h2, .h2 { font-size: @font-size-h2; }
+	h3, .h3 { font-size: @font-size-h3; }
+	h4, .h4 { font-size: @font-size-h4; }
+	h5, .h5 { font-size: @font-size-h5; }
+	h6, .h6 { font-size: @font-size-h6; }
 
-p {
-	font-size: @font-size-base;
+	.h1 { margin: 0; }
+	.h2 { margin: 0; }
+	.h3 { margin: 0; }
+	.h4 { margin: 0; }
+	.h5 { margin: 0; }
+	.h6 { margin: 0; }
 
-	&.support-text{
-		color: @gray40;
+	// Font Family
+	// -------------------------
+	.serif {
+		font-family: Georgia, "Times New Roman", Times, serif;
+	}
+	.monospace {
+		font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 	}
 
-	&.hint-text{
-		color: @gray60;
+	// Font Size
+	// -------------------------
+	.text-sm {
+		font-size: 10px;
+	}
+	.text-lg {
+		font-size: 24px;
+	}
+	.text-xl {
+		font-size: 32px;
+	}
+	.text-xxl {
+		font-size: 44px;
 	}
 
-	&.disabled-text{
-		color: @gray67;
+	// Font Color
+	// -------------------------
+	.text-danger {
+		color: @text-danger;
 	}
-}
-
-h1, .h1 { font-size: @font-size-h1; }
-h2, .h2 { font-size: @font-size-h2; }
-h3, .h3 { font-size: @font-size-h3; }
-h4, .h4 { font-size: @font-size-h4; }
-h5, .h5 { font-size: @font-size-h5; }
-h6, .h6 { font-size: @font-size-h6; }
-
-.h1 { margin: 0; }
-.h2 { margin: 0; }
-.h3 { margin: 0; }
-.h4 { margin: 0; }
-.h5 { margin: 0; }
-.h6 { margin: 0; }
-
-// Font Family
-// -------------------------
-.serif {
-	font-family: Georgia, "Times New Roman", Times, serif;
-}
-.monospace {
-	font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-}
-
-// Font Size
-// -------------------------
-.text-sm {
-	font-size: 10px;
-}
-.text-lg {
-	font-size: 24px;
-}
-.text-xl {
-	font-size: 32px;
-}
-.text-xxl {
-	font-size: 44px;
-}
-
-// Font Color
-// -------------------------
-.text-danger {
-	color: @text-danger;
-}
-.text-dimmed {
-	color: @text-dimmed;
-}
-.text-muted {
-	color: @text-muted;
-}
-.text-primary {
-	color: @text-primary;
-}
-.text-warning {
-	color: @text-warning;
+	.text-dimmed {
+		color: @text-dimmed;
+	}
+	.text-muted {
+		color: @text-muted;
+	}
+	.text-primary {
+		color: @text-primary;
+	}
+	.text-warning {
+		color: @text-warning;
+	}
 }


### PR DESCRIPTION
![screen shot 2015-07-29 at 4 58 28 pm](https://cloud.githubusercontent.com/assets/2026866/8992538/06c72fea-36cd-11e5-82f3-3e5cba830f47.png)

I'm sure you'd rather do this some other way, but I needed to compile a fix for a prototype, so here it is.