### PR TITLE
Highlight icon markup to allow copying to clipboard

### DIFF
--- a/examples/css/super-copy.css
+++ b/examples/css/super-copy.css
@@ -1,0 +1,12 @@
+.super-copy {
+	position: absolute;
+	top: 0;
+	right: 0;
+	z-index: 10;
+	display: block;
+	padding: 2px 3px;
+	color: #767676;
+	cursor: pointer;
+	background-color: #fff;
+	border: 1px solid #e1e1e8;
+}

--- a/examples/icons/icons-examples.css
+++ b/examples/icons/icons-examples.css
@@ -7,21 +7,6 @@ body {
 	padding-top: 60px;
 }
 
-
-.super-copy {
-	position: absolute;
-	top: 0;
-	right: 0;
-	z-index: 10;
-	display: block;
-	padding: 2px 3px;
-	font-size: 12px;
-	color: #767676;
-	cursor: pointer;
-	background-color: #fff;
-	border: 1px solid #e1e1e8;
-}
-
 #docnav .navbar-nav > li > a {
 	color: #fff;
 	padding: 15px;

--- a/examples/icons/icons.html
+++ b/examples/icons/icons.html
@@ -7,6 +7,7 @@
 	<link href="/bower_components/fuelux/dist/css/fuelux.css" rel="stylesheet" type="text/css">
 	<link href="/dist/css/fuelux-mctheme.css" rel="stylesheet" type="text/css">
 	<link href="/examples/icons/icons-examples.css" rel="stylesheet" type="text/css">
+	<link href="/examples/css/super-copy.css"  rel="stylesheet" type="text/css">
 </head>
 <body>
 <header id="docnav" class="navbar navbar-fixed-top" role="banner">
@@ -66,10 +67,8 @@
 										<span class="fuelux-icon fuelux-icon-add-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-add-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-add-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -91,10 +90,8 @@
 										<span class="fuelux-icon fuelux-icon-add"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-add"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-add"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -116,10 +113,8 @@
 										<span class="fuelux-icon fuelux-icon-arrow-east-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-arrow-east-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-arrow-east-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -141,10 +136,8 @@
 										<span class="fuelux-icon fuelux-icon-arrow-east"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-arrow-east"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-arrow-east"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -166,10 +159,8 @@
 										<span class="fuelux-icon fuelux-icon-arrow-north-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-arrow-north-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-arrow-north-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -191,10 +182,8 @@
 										<span class="fuelux-icon fuelux-icon-arrow-north"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-arrow-north"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-arrow-north"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -220,10 +209,8 @@
 										<span class="fuelux-icon fuelux-icon-arrow-south-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-arrow-south-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-arrow-south-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -245,10 +232,8 @@
 										<span class="fuelux-icon fuelux-icon-arrow-south"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-arrow-south"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-arrow-south"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -270,10 +255,8 @@
 										<span class="fuelux-icon fuelux-icon-arrow-west-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-arrow-west-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-arrow-west-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -295,10 +278,8 @@
 										<span class="fuelux-icon fuelux-icon-arrow-west"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-arrow-west"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-arrow-west"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -320,10 +301,8 @@
 										<span class="fuelux-icon fuelux-icon-breadcrumb"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-breadcrumb"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-breadcrumb"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -345,10 +324,8 @@
 										<span class="fuelux-icon fuelux-icon-calendar-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-calendar-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-calendar-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -374,10 +351,8 @@
 										<span class="fuelux-icon fuelux-icon-calendar"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-calendar"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-calendar"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -399,10 +374,8 @@
 										<span class="fuelux-icon fuelux-icon-caret-down-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-caret-down-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-caret-down-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -424,10 +397,8 @@
 										<span class="fuelux-icon fuelux-icon-caret-down"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-caret-down"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-caret-down"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -449,10 +420,8 @@
 										<span class="fuelux-icon fuelux-icon-caret-left-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-caret-left-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-caret-left-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -474,10 +443,8 @@
 										<span class="fuelux-icon fuelux-icon-caret-left"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-caret-left"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-caret-left"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -499,10 +466,8 @@
 										<span class="fuelux-icon fuelux-icon-caret-right-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-caret-right-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-caret-right-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -528,10 +493,8 @@
 										<span class="fuelux-icon fuelux-icon-caret-right"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-caret-right"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-caret-right"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -553,10 +516,8 @@
 										<span class="fuelux-icon fuelux-icon-caret-up-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-caret-up-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-caret-up-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -578,10 +539,8 @@
 										<span class="fuelux-icon fuelux-icon-caret-up"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-caret-up"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-caret-up"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -603,10 +562,8 @@
 										<span class="fuelux-icon fuelux-icon-channel-pin-blue"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-channel-pin-blue"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-channel-pin-blue"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -628,10 +585,8 @@
 										<span class="fuelux-icon fuelux-icon-channel-pin-green"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-channel-pin-green"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-channel-pin-green"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -653,10 +608,8 @@
 										<span class="fuelux-icon fuelux-icon-channel-pin-red"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-channel-pin-red"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-channel-pin-red"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -682,10 +635,8 @@
 										<span class="fuelux-icon fuelux-icon-channel-pin"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-channel-pin"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-channel-pin"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -707,10 +658,8 @@
 										<span class="fuelux-icon fuelux-icon-checkbox-active-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-active-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-active-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -732,10 +681,8 @@
 										<span class="fuelux-icon fuelux-icon-checkbox-active"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-active"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-active"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -757,10 +704,8 @@
 										<span class="fuelux-icon fuelux-icon-checkbox-checked-disabled"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-checked-disabled"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-checked-disabled"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -782,10 +727,8 @@
 										<span class="fuelux-icon fuelux-icon-checkbox-checked-hover-active"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-checked-hover-active"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-checked-hover-active"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -807,10 +750,8 @@
 										<span class="fuelux-icon fuelux-icon-checkbox-checked-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-checked-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-checked-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -836,10 +777,8 @@
 										<span class="fuelux-icon fuelux-icon-checkbox-checked"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-checked"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-checked"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -861,10 +800,8 @@
 										<span class="fuelux-icon fuelux-icon-checkbox-disabled"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-disabled"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-disabled"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -886,10 +823,8 @@
 										<span class="fuelux-icon fuelux-icon-checkbox-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -911,10 +846,8 @@
 										<span class="fuelux-icon fuelux-icon-checkbox-indeterminate-disabled"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-indeterminate-disabled"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-indeterminate-disabled"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -936,10 +869,8 @@
 										<span class="fuelux-icon fuelux-icon-checkbox-indeterminate-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-indeterminate-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-indeterminate-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -961,10 +892,8 @@
 										<span class="fuelux-icon fuelux-icon-checkbox-indeterminate"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-indeterminate"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checkbox-indeterminate"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -990,10 +919,8 @@
 										<span class="fuelux-icon fuelux-icon-checkbox"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checkbox"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checkbox"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1015,10 +942,8 @@
 										<span class="fuelux-icon fuelux-icon-checked-indicator-green"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checked-indicator-green"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checked-indicator-green"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1040,10 +965,8 @@
 										<span class="fuelux-icon fuelux-icon-checked-indicator-grey"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checked-indicator-grey"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checked-indicator-grey"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1065,10 +988,8 @@
 										<span class="fuelux-icon fuelux-icon-checked-indicator-white"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checked-indicator-white"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checked-indicator-white"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1090,10 +1011,8 @@
 										<span class="fuelux-icon fuelux-icon-checked-indicator"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-checked-indicator"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-checked-indicator"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1115,10 +1034,8 @@
 										<span class="fuelux-icon fuelux-icon-chevron-down"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-chevron-down"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-chevron-down"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1144,10 +1061,8 @@
 										<span class="fuelux-icon fuelux-icon-chevron-left-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-chevron-left-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-chevron-left-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1169,10 +1084,8 @@
 										<span class="fuelux-icon fuelux-icon-chevron-left"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-chevron-left"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-chevron-left"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1194,10 +1107,8 @@
 										<span class="fuelux-icon fuelux-icon-chevron-right-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-chevron-right-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-chevron-right-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1219,10 +1130,8 @@
 										<span class="fuelux-icon fuelux-icon-chevron-right"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-chevron-right"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-chevron-right"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1244,10 +1153,8 @@
 										<span class="fuelux-icon fuelux-icon-chevron-up"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-chevron-up"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-chevron-up"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1269,10 +1176,8 @@
 										<span class="fuelux-icon fuelux-icon-close-content-block"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-close-content-block"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-close-content-block"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1298,10 +1203,8 @@
 										<span class="fuelux-icon fuelux-icon-copy-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-copy-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-copy-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1323,10 +1226,8 @@
 										<span class="fuelux-icon fuelux-icon-copy"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-copy"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-copy"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1348,10 +1249,8 @@
 										<span class="fuelux-icon fuelux-icon-danger"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-danger"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-danger"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1373,10 +1272,8 @@
 										<span class="fuelux-icon fuelux-icon-default-size-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-default-size-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-default-size-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1398,10 +1295,8 @@
 										<span class="fuelux-icon fuelux-icon-default-size"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-default-size"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-default-size"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1423,10 +1318,8 @@
 										<span class="fuelux-icon fuelux-icon-delete"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-delete"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-delete"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1452,10 +1345,8 @@
 										<span class="fuelux-icon fuelux-icon-dot-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-dot-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-dot-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1477,10 +1368,8 @@
 										<span class="fuelux-icon fuelux-icon-dot"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-dot"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-dot"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1502,10 +1391,8 @@
 										<span class="fuelux-icon fuelux-icon-download-document-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-download-document-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-download-document-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1527,10 +1414,8 @@
 										<span class="fuelux-icon fuelux-icon-download-document"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-download-document"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-download-document"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1552,10 +1437,8 @@
 										<span class="fuelux-icon fuelux-icon-download-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-download-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-download-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1577,10 +1460,8 @@
 										<span class="fuelux-icon fuelux-icon-download"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-download"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-download"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1606,10 +1487,8 @@
 										<span class="fuelux-icon fuelux-icon-email-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-email-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-email-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1631,10 +1510,8 @@
 										<span class="fuelux-icon fuelux-icon-email"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-email"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-email"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1656,10 +1533,8 @@
 										<span class="fuelux-icon fuelux-icon-facebook-page"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-facebook-page"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-facebook-page"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1681,10 +1556,8 @@
 										<span class="fuelux-icon fuelux-icon-facebook"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-facebook"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-facebook"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1706,10 +1579,8 @@
 										<span class="fuelux-icon fuelux-icon-folder-close"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-folder-close"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-folder-close"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1731,10 +1602,8 @@
 										<span class="fuelux-icon fuelux-icon-folder-open"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-folder-open"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-folder-open"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1760,10 +1629,8 @@
 										<span class="fuelux-icon fuelux-icon-full-size-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-full-size-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-full-size-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1785,10 +1652,8 @@
 										<span class="fuelux-icon fuelux-icon-full-size"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-full-size"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-full-size"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1810,10 +1675,8 @@
 										<span class="fuelux-icon fuelux-icon-gear-blue"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-gear-blue"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-gear-blue"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1835,10 +1698,8 @@
 										<span class="fuelux-icon fuelux-icon-gear-grey"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-gear-grey"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-gear-grey"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1860,10 +1721,8 @@
 										<span class="fuelux-icon fuelux-icon-gear-white"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-gear-white"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-gear-white"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1885,10 +1744,8 @@
 										<span class="fuelux-icon fuelux-icon-gears-blue"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-gears-blue"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-gears-blue"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1914,10 +1771,8 @@
 										<span class="fuelux-icon fuelux-icon-gears-grey"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-gears-grey"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-gears-grey"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1939,10 +1794,8 @@
 										<span class="fuelux-icon fuelux-icon-gears-white"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-gears-white"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-gears-white"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1964,10 +1817,8 @@
 										<span class="fuelux-icon fuelux-icon-gridview-columns-configure"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-gridview-columns-configure"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-gridview-columns-configure"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -1989,10 +1840,8 @@
 										<span class="fuelux-icon fuelux-icon-gridview-columns"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-gridview-columns"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-gridview-columns"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2014,10 +1863,8 @@
 										<span class="fuelux-icon fuelux-icon-gridview-list"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-gridview-list"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-gridview-list"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2039,10 +1886,8 @@
 										<span class="fuelux-icon fuelux-icon-gridview-paragraph"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-gridview-paragraph"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-gridview-paragraph"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2068,10 +1913,8 @@
 										<span class="fuelux-icon fuelux-icon-gridview-performance"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-gridview-performance"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-gridview-performance"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2093,10 +1936,8 @@
 										<span class="fuelux-icon fuelux-icon-gridview-thumbnail"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-gridview-thumbnail"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-gridview-thumbnail"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2118,10 +1959,8 @@
 										<span class="fuelux-icon fuelux-icon-help-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-help-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-help-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2143,10 +1982,8 @@
 										<span class="fuelux-icon fuelux-icon-help"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-help"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-help"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2168,10 +2005,8 @@
 										<span class="fuelux-icon fuelux-icon-info"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-info"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-info"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2193,10 +2028,8 @@
 										<span class="fuelux-icon fuelux-icon-line"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-line"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-line"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2222,10 +2055,8 @@
 										<span class="fuelux-icon fuelux-icon-loader"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-loader"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-loader"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2247,10 +2078,8 @@
 										<span class="fuelux-icon fuelux-icon-message-type-in"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-message-type-in"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-message-type-in"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2272,10 +2101,8 @@
 										<span class="fuelux-icon fuelux-icon-message-type-out"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-message-type-out"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-message-type-out"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2297,10 +2124,8 @@
 										<span class="fuelux-icon fuelux-icon-minus-sign-disabled"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-minus-sign-disabled"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-minus-sign-disabled"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2322,10 +2147,8 @@
 										<span class="fuelux-icon fuelux-icon-minus-sign-grey"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-minus-sign-grey"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-minus-sign-grey"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2347,10 +2170,8 @@
 										<span class="fuelux-icon fuelux-icon-minus-sign-white"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-minus-sign-white"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-minus-sign-white"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2376,10 +2197,8 @@
 										<span class="fuelux-icon fuelux-icon-minus-sign"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-minus-sign"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-minus-sign"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2401,10 +2220,8 @@
 										<span class="fuelux-icon fuelux-icon-mobile-push"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-mobile-push"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-mobile-push"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2426,10 +2243,8 @@
 										<span class="fuelux-icon fuelux-icon-mobile-sms-deprecated"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-mobile-sms-deprecated"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-mobile-sms-deprecated"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2451,10 +2266,8 @@
 										<span class="fuelux-icon fuelux-icon-mobile-sms"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-mobile-sms"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-mobile-sms"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2476,10 +2289,8 @@
 										<span class="fuelux-icon fuelux-icon-pencil-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-pencil-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-pencil-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2501,10 +2312,8 @@
 										<span class="fuelux-icon fuelux-icon-pencil"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-pencil"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-pencil"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2530,10 +2339,8 @@
 										<span class="fuelux-icon fuelux-icon-people"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-people"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-people"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2555,10 +2362,8 @@
 										<span class="fuelux-icon fuelux-icon-person"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-person"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-person"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2580,10 +2385,8 @@
 										<span class="fuelux-icon fuelux-icon-plus-sign-disabled"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-plus-sign-disabled"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-plus-sign-disabled"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2605,10 +2408,8 @@
 										<span class="fuelux-icon fuelux-icon-plus-sign-grey"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-plus-sign-grey"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-plus-sign-grey"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2630,10 +2431,8 @@
 										<span class="fuelux-icon fuelux-icon-plus-sign-white"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-plus-sign-white"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-plus-sign-white"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2655,10 +2454,8 @@
 										<span class="fuelux-icon fuelux-icon-plus-sign"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-plus-sign"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-plus-sign"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2684,10 +2481,8 @@
 										<span class="fuelux-icon fuelux-icon-radio-button-active-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-active-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-active-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2709,10 +2504,8 @@
 										<span class="fuelux-icon fuelux-icon-radio-button-active"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-active"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-active"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2734,10 +2527,8 @@
 										<span class="fuelux-icon fuelux-icon-radio-button-checked-disabled"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-checked-disabled"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-checked-disabled"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2759,10 +2550,8 @@
 										<span class="fuelux-icon fuelux-icon-radio-button-checked-hover-active"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-checked-hover-active"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-checked-hover-active"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2784,10 +2573,8 @@
 										<span class="fuelux-icon fuelux-icon-radio-button-checked-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-checked-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-checked-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2809,10 +2596,8 @@
 										<span class="fuelux-icon fuelux-icon-radio-button-checked"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-checked"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-checked"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2838,10 +2623,8 @@
 										<span class="fuelux-icon fuelux-icon-radio-button-disabled"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-disabled"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-disabled"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2863,10 +2646,8 @@
 										<span class="fuelux-icon fuelux-icon-radio-button-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-radio-button-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2888,10 +2669,8 @@
 										<span class="fuelux-icon fuelux-icon-radio-button"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-radio-button"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-radio-button"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2913,10 +2692,8 @@
 										<span class="fuelux-icon fuelux-icon-refresh-disabled"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-refresh-disabled"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-refresh-disabled"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2938,10 +2715,8 @@
 										<span class="fuelux-icon fuelux-icon-refresh-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-refresh-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-refresh-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2963,10 +2738,8 @@
 										<span class="fuelux-icon fuelux-icon-refresh"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-refresh"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-refresh"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -2992,10 +2765,8 @@
 										<span class="fuelux-icon fuelux-icon-remove-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-remove-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-remove-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3017,10 +2788,8 @@
 										<span class="fuelux-icon fuelux-icon-remove"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-remove"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-remove"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3042,10 +2811,8 @@
 										<span class="fuelux-icon fuelux-icon-return-to-top-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-return-to-top-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-return-to-top-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3067,10 +2834,8 @@
 										<span class="fuelux-icon fuelux-icon-return-to-top"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-return-to-top"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-return-to-top"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3092,10 +2857,8 @@
 										<span class="fuelux-icon fuelux-icon-schematic"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-schematic"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-schematic"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3117,10 +2880,8 @@
 										<span class="fuelux-icon fuelux-icon-search-active-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-search-active-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-search-active-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3146,10 +2907,8 @@
 										<span class="fuelux-icon fuelux-icon-search-active"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-search-active"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-search-active"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3171,10 +2930,8 @@
 										<span class="fuelux-icon fuelux-icon-search-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-search-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-search-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3196,10 +2953,8 @@
 										<span class="fuelux-icon fuelux-icon-search"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-search"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-search"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3221,10 +2976,8 @@
 										<span class="fuelux-icon fuelux-icon-sort-by-alphabet"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-sort-by-alphabet"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-sort-by-alphabet"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3246,10 +2999,8 @@
 										<span class="fuelux-icon fuelux-icon-spyglass-green"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-spyglass-green"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-spyglass-green"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3271,10 +3022,8 @@
 										<span class="fuelux-icon fuelux-icon-spyglass-grey"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-spyglass-grey"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-spyglass-grey"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3300,10 +3049,8 @@
 										<span class="fuelux-icon fuelux-icon-spyglass-white"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-spyglass-white"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-spyglass-white"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3325,10 +3072,8 @@
 										<span class="fuelux-icon fuelux-icon-spyglass"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-spyglass"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-spyglass"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3350,10 +3095,8 @@
 										<span class="fuelux-icon fuelux-icon-subtract-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-subtract-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-subtract-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3375,10 +3118,8 @@
 										<span class="fuelux-icon fuelux-icon-subtract"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-subtract"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-subtract"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3400,10 +3141,8 @@
 										<span class="fuelux-icon fuelux-icon-success"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-success"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-success"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3425,10 +3164,8 @@
 										<span class="fuelux-icon fuelux-icon-thumbs-down-blue"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-down-blue"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-down-blue"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3454,10 +3191,8 @@
 										<span class="fuelux-icon fuelux-icon-thumbs-down-green"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-down-green"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-down-green"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3479,10 +3214,8 @@
 										<span class="fuelux-icon fuelux-icon-thumbs-down-grey"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-down-grey"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-down-grey"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3504,10 +3237,8 @@
 										<span class="fuelux-icon fuelux-icon-thumbs-down-orange"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-down-orange"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-down-orange"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3529,10 +3260,8 @@
 										<span class="fuelux-icon fuelux-icon-thumbs-down-red"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-down-red"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-down-red"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3554,10 +3283,8 @@
 										<span class="fuelux-icon fuelux-icon-thumbs-down-white"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-down-white"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-down-white"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3579,10 +3306,8 @@
 										<span class="fuelux-icon fuelux-icon-thumbs-up-blue"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-up-blue"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-up-blue"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3608,10 +3333,8 @@
 										<span class="fuelux-icon fuelux-icon-thumbs-up-green"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-up-green"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-up-green"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3633,10 +3356,8 @@
 										<span class="fuelux-icon fuelux-icon-thumbs-up-grey"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-up-grey"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-up-grey"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3658,10 +3379,8 @@
 										<span class="fuelux-icon fuelux-icon-thumbs-up-orange"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-up-orange"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-up-orange"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3683,10 +3402,8 @@
 										<span class="fuelux-icon fuelux-icon-thumbs-up-red"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-up-red"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-up-red"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3708,10 +3425,8 @@
 										<span class="fuelux-icon fuelux-icon-thumbs-up-white"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-up-white"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-thumbs-up-white"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3733,10 +3448,8 @@
 										<span class="fuelux-icon fuelux-icon-trash-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-trash-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-trash-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3762,10 +3475,8 @@
 										<span class="fuelux-icon fuelux-icon-trash"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-trash"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-trash"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3787,10 +3498,8 @@
 										<span class="fuelux-icon fuelux-icon-triangle-east-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-triangle-east-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-triangle-east-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3812,10 +3521,8 @@
 										<span class="fuelux-icon fuelux-icon-triangle-east"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-triangle-east"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-triangle-east"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3837,10 +3544,8 @@
 										<span class="fuelux-icon fuelux-icon-triangle-north-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-triangle-north-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-triangle-north-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3862,10 +3567,8 @@
 										<span class="fuelux-icon fuelux-icon-triangle-north"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-triangle-north"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-triangle-north"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3887,10 +3590,8 @@
 										<span class="fuelux-icon fuelux-icon-triangle-south-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-triangle-south-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-triangle-south-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3916,10 +3617,8 @@
 										<span class="fuelux-icon fuelux-icon-triangle-south"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-triangle-south"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-triangle-south"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3941,10 +3640,8 @@
 										<span class="fuelux-icon fuelux-icon-triangle-west-hover"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-triangle-west-hover"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-triangle-west-hover"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3966,10 +3663,8 @@
 										<span class="fuelux-icon fuelux-icon-triangle-west"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-triangle-west"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-triangle-west"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -3991,10 +3686,8 @@
 										<span class="fuelux-icon fuelux-icon-twitter"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-twitter"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-twitter"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -4016,10 +3709,8 @@
 										<span class="fuelux-icon fuelux-icon-warning"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-warning"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-warning"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -4041,10 +3732,8 @@
 										<span class="fuelux-icon fuelux-icon-x-blue-disabled"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-x-blue-disabled"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-x-blue-disabled"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -4070,10 +3759,8 @@
 										<span class="fuelux-icon fuelux-icon-x-blue"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-x-blue"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-x-blue"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -4095,10 +3782,8 @@
 										<span class="fuelux-icon fuelux-icon-x-grey"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-x-grey"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-x-grey"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -4120,10 +3805,8 @@
 										<span class="fuelux-icon fuelux-icon-x-white"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-x-white"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-x-white"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -4145,10 +3828,8 @@
 										<span class="fuelux-icon fuelux-icon-zoom-in"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-zoom-in"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-zoom-in"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -4170,10 +3851,8 @@
 										<span class="fuelux-icon fuelux-icon-zoom-out"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-zoom-out"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-zoom-out"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -4184,19 +3863,7 @@
 	</div>
 </div>
 <script src="/bower_components/jquery/dist/jquery.js"></script>
-<script>
-	$('code').each(function() {
-		var code = $(this).text();
-		$(this).parent().parent()
-				.css('position', 'relative')
-				.append(
-				$('<div class="super-copy">Copy</div>')
-						.click(function() {
-							window.prompt("Copy to clipboard: Ctrl+C (cmd+c), Enter", code);
-						})
-		);
-	});
-</script>
+<script src="/examples/scripts/super-copy.js"></script>
 <script src="//localhost:35730/livereload.js"></script>
 </body>
 </html>

--- a/examples/scripts/super-copy.js
+++ b/examples/scripts/super-copy.js
@@ -1,0 +1,53 @@
+
+$(function() {
+    var COPY_PROMPT_TEXT = 'copy';
+    var KEYSTROKE_TEXT = '⌘ + c (ctrl + c)';
+
+    var selectCode = function($el) {
+        var doc = document;
+        var code = $el.parent().find('code')[0];
+
+        if (doc.body.createcodeRange) {
+            var range = document.body.createcodeRange();
+            range.moveToElementcode(code);
+            range.select();
+        }
+        else if (window.getSelection) {
+            var selection = window.getSelection();
+            var range = document.createRange();
+            range.selectNodeContents(code);
+            selection.removeAllRanges();
+            selection.addRange(range);
+        }
+    };
+
+    var $copyPrompt = $('<div>')
+        .text(COPY_PROMPT_TEXT)
+        .addClass('super-copy small')
+        ;
+
+    var applySuperCopy = function($currentCode) {
+        $currentCode.parent()
+            .css('position', 'relative')
+            .append($copyPrompt.clone()
+                    .click(function() {
+                        debugger;
+                        onCopyClick($(this));
+                    })
+                   )
+            ;
+    }
+
+    var onCopyClick = function($currentPrompt) {
+        selectCode($currentPrompt);
+        $currentPrompt.text(KEYSTROKE_TEXT);
+
+        setTimeout(function() {
+            $currentPrompt.text(COPY_PROMPT_TEXT);
+        }, 3000);
+    };
+
+    $('code').each(function() {
+        applySuperCopy($(this));
+    });
+});

--- a/icons/preview-custom.hbs
+++ b/icons/preview-custom.hbs
@@ -7,7 +7,7 @@
 	<link href="/bower_components/fuelux/dist/css/fuelux.css" rel="stylesheet" type="text/css">
 	<link href="/dist/css/fuelux-mctheme.css" rel="stylesheet" type="text/css">
 	<link href="/examples/icons/icons-examples.css" rel="stylesheet" type="text/css">
-	<link href="/examples/css/super-copy.css" />
+	<link href="/examples/css/super-copy.css"  rel="stylesheet" type="text/css">
 </head>
 <body>
 <header id="docnav" class="navbar navbar-fixed-top" role="banner">

--- a/icons/preview-custom.hbs
+++ b/icons/preview-custom.hbs
@@ -7,6 +7,7 @@
 	<link href="/bower_components/fuelux/dist/css/fuelux.css" rel="stylesheet" type="text/css">
 	<link href="/dist/css/fuelux-mctheme.css" rel="stylesheet" type="text/css">
 	<link href="/examples/icons/icons-examples.css" rel="stylesheet" type="text/css">
+	<link href="/examples/css/super-copy.css" />
 </head>
 <body>
 <header id="docnav" class="navbar navbar-fixed-top" role="banner">
@@ -66,10 +67,8 @@
 										<span class="fuelux-icon fuelux-icon-{{name}}"></span> Button Link
 									</button>
 								</div>
-								<div class="panel-footer">
-									<small>
-										<code>&lt;span class="fuelux-icon fuelux-icon-{{name}}"&gt;&lt;/span&gt;</code>
-									</small>
+								<div class="panel-footer small">
+									<code>&lt;span class="fuelux-icon fuelux-icon-{{name}}"&gt;&lt;/span&gt;</code>
 								</div>
 							</div>
 						</div>
@@ -80,19 +79,7 @@
 	</div>
 </div>
 <script src="/bower_components/jquery/dist/jquery.js"></script>
-<script>
-	$('code').each(function() {
-		var code = $(this).text();
-		$(this).parent().parent()
-				.css('position', 'relative')
-				.append(
-				$('<div class="super-copy">Copy</div>')
-						.click(function() {
-							window.prompt("Copy to clipboard: Ctrl+C (cmd+c), Enter", code);
-						})
-		);
-	});
-</script>
+<script src="/examples/scripts/super-copy.js"></script>
 <script src="//localhost:35730/livereload.js"></script>
 </body>
 </html>


### PR DESCRIPTION
moving to a select code paradigm instead of prompt.

prompt doesn't allow for copying whitespace. also modularized so easy to drop in other pages.