### PR TITLE
Spacing token: change PX to px

### DIFF
--- a/tokens/fuelux/spacing.json
+++ b/tokens/fuelux/spacing.json
@@ -16,7 +16,7 @@
       "value": "8px"
     },
     "SPACING_SMALL": {
-      "value": "12PX"
+      "value": "12px"
     },
     "SPACING_MEDIUM": {
       "value": "16px"


### PR DESCRIPTION
This shouldn't affect browser parsing of CSS, but needs to fixed nonetheless. I was unable to find any data about browsers failing due to case. The spec says it shouldn't be a problem: https://drafts.csswg.org/css-values/#keywords