### PR TITLE
Only runs bower if ENV var INSTALL_BOWER is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "postinstall": "bower install",
+    "postinstall": "node postinstall.js",
     "start": "node www/server.js"
   },
   "dependencies": {

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,4 @@
+
+if (process.env.INSTALL_BOWER === 'true') {
+   require("bower").commands.install();
+}


### PR DESCRIPTION
I was using mctheme via NPM and the bower install was going crazy and is not needed. 

This makes if that you have to run `bower install` if you are using bower now and do not have ENV variables set. Also aligns with Fuel UX project.