### PR TITLE
Add in support for btn-secondary

### DIFF
--- a/less/bootstrap-override/buttons.less
+++ b/less/bootstrap-override/buttons.less
@@ -66,7 +66,10 @@
 
 // Alternate buttons
 // --------------------------------------------------
-.btn-default {
+
+// .btn-secondary is only present for compatibility with bootstrap and MCtheme 
+// prior to v1.8.0. Please do not use .btn-secondary
+.btn-default, .btn-secondary {
 	//because this button has 1px border, padding needs to be adjusted
 	//padding + border = 5px
 	padding: 4px 10px;


### PR DESCRIPTION
For the second time….ironically!

*Not added to examples pages in order to not promote use.*

Sample HTML:
`<button type="button" class="btn btn-secondary">Secondary</button>`