### PR TITLE
Add specifity to prevent Fuel UX module from installing bower

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -1,4 +1,4 @@
 
-if (process.env.INSTALL_BOWER === 'true') {
+if (process.env.INSTALL_FUELUX_MCTHEME_BOWER === 'true') {
    require("bower").commands.install();
 }


### PR DESCRIPTION
Currently `INSTALL_BOWER` env variable is the same within Fuel UX and Fuel UX McTheme. This changes that, so cyclical bower install doesn't happen when Fuel UX module is npm installed within/via MCtheme.

![screen shot 2015-10-02 at 4 31 08 pm](https://cloud.githubusercontent.com/assets/1290832/10257032/054600b4-6923-11e5-8360-e81dff1c74ba.png)