### PR TITLE
adds input-group-addon styles, and example

### DIFF
--- a/examples/fuelux/fuelux.html
+++ b/examples/fuelux/fuelux.html
@@ -173,6 +173,25 @@
 									</label>
 								</div>
 							</section>
+							<section id="checkbox-add-on" class="x-panel x-panel-default">
+								<header class="hidden x-panel-heading">
+									<h3 class="panel-title">Checkbox within input-group-addon</h3>
+								</header>
+								<section class="x-panel-body">
+									<div class="input-group" id="inputwithcheckbox">
+										<input id="inputwithcheckboxInput" name="inputwithcheckboxInput" class=" form-control" placeholder="placeholder">
+										<label class="input-group-addon checkbox-custom" data-initialize="checkbox">
+											<input class="sr-only" type="checkbox" aria-label="..." id="inputwithcheckboxCheckbox" value="option1">
+										</label>
+									</div>
+									<div class="input-group" id="inputwithcheckbox">
+										<label class="input-group-addon checkbox-custom" data-initialize="checkbox">
+											<input class="sr-only" type="checkbox" aria-label="..." id="inputwithcheckboxCheckbox" value="option1">
+										</label>
+										<input id="inputwithcheckboxInput" name="inputwithcheckboxInput" class=" form-control" placeholder="placeholder">
+									</div><!-- /input-group -->
+								</section>
+							</section>
 							<section id="checkboxes-highlighting-inline">
 								<label class="checkbox-custom checkbox-inline highlight" data-initialize="checkbox" id="myCustomHighlightCheckbox5">
 									<input class="sr-only" type="checkbox" value=""> <span class="checkbox-label">Custom inline highlight checkbox</span>

--- a/less/fuelux-override/checkbox.less
+++ b/less/fuelux-override/checkbox.less
@@ -3,7 +3,7 @@
 	height: @checkbox-height;
 }
 .checkbox-before() {
-	
+
 	input[type="checkbox"] {
 		height: 1px;
 		width: 1px;
@@ -103,6 +103,17 @@
 		}
 		input[type="checkbox"] {
 			position: absolute;
+		}
+	}
+
+	// Fuel UX Checkboxes in input groups
+	// -------------------------
+	&.input-group-addon {
+		padding-left: 16px;
+
+		&:before {
+			left: 4px;
+			top: 3px;
 		}
 	}
 }


### PR DESCRIPTION
IE11
![image](https://cloud.githubusercontent.com/assets/8006971/11571855/6e2c8ae2-99cc-11e5-828b-98c7f2bf539b.png)

IE10
![image](https://cloud.githubusercontent.com/assets/8006971/11571875/83310af8-99cc-11e5-8fc9-9786bc115bd3.png)

Firefox
![image](https://cloud.githubusercontent.com/assets/8006971/11571882/89d31784-99cc-11e5-8b78-7ba655c33077.png)

Chrome
![image](https://cloud.githubusercontent.com/assets/8006971/11571871/7c0c1330-99cc-11e5-8c2f-27ef5c365b01.png)

Fixes #431 
Related to https://github.exacttarget.com/uxarchitecture/fuelux-site/issues/4
