### PR TITLE
Fix button toggle not working sometimes in Firefox

### DIFF
--- a/less/bootstrap-override/buttons.less
+++ b/less/bootstrap-override/buttons.less
@@ -216,22 +216,8 @@ input[type="button"] {
 		font-size: 0;
 	}
 
-	label:active,
-	label:active:hover,
 	label.active,
-	label.active:hover,
-	label:focus,
-	label:focus:hover,
-	label.focus,
-	label.focus:hover,
-	label:focus.active,
-	label:focus.active:hover,
-	label.focus:active,
-	label.focus:active:hover,
-	label:focus:active,
-	label:focus:active:hover,
-	label.focus.active,
-	label.focus.active:hover
+	label.active:hover
    	{
 		background: none;
 		background-color: @brand-primary-medium; // light blue

--- a/less/bootstrap-override/buttons.less
+++ b/less/bootstrap-override/buttons.less
@@ -217,7 +217,11 @@ input[type="button"] {
 	}
 
 	label.active,
-	label.active:hover
+	label.active:hover,
+	label:focus.active,
+	label:focus.active:hover,
+	label.focus.active,
+	label.focus.active:hover
    	{
 		background: none;
 		background-color: @brand-primary-medium; // light blue


### PR DESCRIPTION
In Firefox, clicking anywhere the span inside the button would show up
causes the button press not to be registered. This fix causes the span
to only appear when the button has the active class and after the click,
not during, fixing the issue in Firefox.