### PR TITLE
Remove bower postinstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ To work on the Marketing Cloud theme:
    ```
    git clone https://github.com/ExactTarget/fuelux-mctheme/
    ```
-1. Run npm install:
+1. Run npm setup:
   ```
-  npm install
+  npm run setup
   ```
 1. Start up the server:
   ```

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": "4.4.2"
   },
   "scripts": {
-    "postinstall": "./node_modules/.bin/bower install",
+    "setup": "npm install && ./node_modules/.bin/bower install",
     "start": "node www/server.js"
   },
   "dependencies": {


### PR DESCRIPTION
The postinstall script caused every repository that consumes
fuelux-mctheme to perform a bower install. This was unnecessary and
wasteful. To keep local setup easy, a "setup" script was added that will
perform both npm install and bower install.